### PR TITLE
Update gitversion.yml

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,2 +1,1 @@
 mode: ContinuousDeployment
-continuous-delivery-fallback-tag: ''


### PR DESCRIPTION
Removing fallback tag override so that tagging in Github is used for releases